### PR TITLE
[hotfix] added missing xmlns

### DIFF
--- a/cob3-2/calibration/calibration_offset.urdf.xacro
+++ b/cob3-2/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob3-6/calibration/calibration_offset.urdf.xacro
+++ b/cob3-6/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob3-9/calibration/calibration_offset.urdf.xacro
+++ b/cob3-9/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-1/calibration/calibration_offset.urdf.xacro
+++ b/cob4-1/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-10/calibration/calibration_offset.urdf.xacro
+++ b/cob4-10/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-2/calibration/calibration_offset.urdf.xacro
+++ b/cob4-2/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-3/calibration/calibration_offset.urdf.xacro
+++ b/cob4-3/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-4/calibration/calibration_offset.urdf.xacro
+++ b/cob4-4/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-5/calibration/calibration_offset.urdf.xacro
+++ b/cob4-5/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-6/calibration/calibration_offset.urdf.xacro
+++ b/cob4-6/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/cob4-7/calibration/calibration_offset.urdf.xacro
+++ b/cob4-7/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/raw3-1/calibration/calibration_offset.urdf.xacro
+++ b/raw3-1/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/raw3-2/calibration/calibration_offset.urdf.xacro
+++ b/raw3-2/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/raw3-3/calibration/calibration_offset.urdf.xacro
+++ b/raw3-3/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/raw3-4/calibration/calibration_offset.urdf.xacro
+++ b/raw3-4/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/raw3-5/calibration/calibration_offset.urdf.xacro
+++ b/raw3-5/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->

--- a/raw3-6/calibration/calibration_offset.urdf.xacro
+++ b/raw3-6/calibration/calibration_offset.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 	<!-- ***************** -->
 	<!-- base calibration -->
 	<!-- ***************** -->


### PR DESCRIPTION
XML namespace cannot be used without declaring them..
All dependent travis jobs fail because of this.
fixes #112 