### PR TITLE
use license apache 2.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="fmw@ipa.fhg.de">Florian Weisshardt</maintainer>
   <maintainer email="nhg@ipa.fhg.de">Nadia Hammoudeh Garcia</maintainer>
 
-  <license>LGPL</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/cob_calibration_data</url>
   <!-- <url type="bugtracker"></url> -->


### PR DESCRIPTION
no external contributors

do not merge before: **August, 4th 2017**
merge together with other `use license apache 2.0` PRs